### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1550,4 +1550,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "a6383c7a2c0510b21cdcb6303d45dce6d7b9f7e75a4b504ca54ec90dfae08065"
+content-hash = "72dc8ce4a2920edd62f14950a9339836cafeb19c8029b30ff6cfb3ab217361f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ prospector-profile-utils = "1.27.0"
 prospector-profile-duplicated = "1.12.0"
 pytest = "9.1.1"
 types-requests = "2.33.0.20260712"
+ruff = "0.16.1"
+pylint = "4.0.6"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.