### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: prospector
         args:
           - --profile=utils:pre-commit
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=.prospector.yaml
         additional_dependencies:
@@ -56,7 +56,7 @@ repos:
           )
       - id: prospector
         args:
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=utils:tests
           - --profile=utils:pre-commit


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.